### PR TITLE
fix: Use getenv() instead of _SERVER vars

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -74,10 +74,12 @@
     }
 
     function __construct() {
-      if(isset($_SERVER['KEYMANHOSTS_TIER']) && in_array($_SERVER['KEYMANHOSTS_TIER'],
+      $env = getenv();
+
+      if(isset($env['KEYMANHOSTS_TIER']) && in_array($env['KEYMANHOSTS_TIER'],
           [KeymanHosts::TIER_DEVELOPMENT, KeymanHosts::TIER_STAGING,
            KeymanHosts::TIER_PRODUCTION, KeymanHosts::TIER_TEST])) {
-        $this->tier = $_SERVER['KEYMANHOSTS_TIER'];
+        $this->tier = $env['KEYMANHOSTS_TIER'];
       } else if(file_exists(__DIR__ . '/../tier.txt')) {
         $this->tier = trim(file_get_contents(__DIR__ . '/../tier.txt'));
       } else {
@@ -104,8 +106,8 @@
       }
 
       // Append reverse-proxy port
-      if (isset($_SERVER['KEYMAN_COM_PROXY_PORT'])) {
-        $site_suffix .= ':'.$_SERVER['KEYMAN_COM_PROXY_PORT'];
+      if (isset($env['KEYMAN_COM_PROXY_PORT'])) {
+        $site_suffix .= ':'.$env['KEYMAN_COM_PROXY_PORT'];
       }
 
       $this->blog_keyman_com = "https://blog.keyman.com";

--- a/_common/KeymanSentry.php
+++ b/_common/KeymanSentry.php
@@ -5,11 +5,9 @@
 
   class KeymanSentry {
     static function init($dsn) {
-      $env = getenv();
-
-      if(isset($env['SERVER_NAME'])) {
+      if(isset($_SERVER['SERVER_NAME'])) {
         // running from web server
-        $host = $env['SERVER_NAME'];
+        $host = $_SERVER['SERVER_NAME'];
         if(preg_match('/\.local$/', $host))
           // If the host name is, e.g. api.keyman.com.local, then we'll assume this is a development environment
           $environment = 'development';

--- a/_common/KeymanSentry.php
+++ b/_common/KeymanSentry.php
@@ -5,9 +5,11 @@
 
   class KeymanSentry {
     static function init($dsn) {
-      if(isset($_SERVER['SERVER_NAME'])) {
+      $env = getenv();
+
+      if(isset($env['SERVER_NAME'])) {
         // running from web server
-        $host = $_SERVER['SERVER_NAME'];
+        $host = $env['SERVER_NAME'];
         if(preg_match('/\.local$/', $host))
           // If the host name is, e.g. api.keyman.com.local, then we'll assume this is a development environment
           $environment = 'development';


### PR DESCRIPTION
Needed for migrating from IIS to Apache

@tim-eves noticed trying to deploy the staging branch of api.keyman.com that the TIER wasn't getting set.

This follows the pattern from https://github.com/keymanapp/api.keyman.com/pull/192/files#diff-5cf5a0aa05c936b7b84e5e8ab31cfde3ac0322b20bf29bce9c9319c8ee2c231bR13