### PR TITLE
fix: Use --add-host parameter on Linux host

### DIFF
--- a/_common/docker.inc.sh
+++ b/_common/docker.inc.sh
@@ -86,10 +86,17 @@ function start_docker_container() {
     SITE_HTML="$(pwd):/var/www/html/"
   fi
 
+  ADD_HOST=
+  if [[ $OSTYPE =~ linux-gnu ]]; then
+    # Linux needs --add-host parameter
+    ADD_HOST="--add-host host.docker.internal:host-gateway"
+  fi
+
   docker run --rm -d -p $PORT:80 -v ${SITE_HTML} \
     -e S_KEYMAN_COM=localhost:$PORT_S_KEYMAN_COM \
     -e API_KEYMAN_COM=localhost:$PORT_API_KEYMAN_COM \
     --name $CONTAINER_DESC \
+    ${ADD_HOST} \
     $CONTAINER_NAME
 
   # Skip if link already exists


### PR DESCRIPTION
This adds the `--add-host` parameter as needed on Linux Docker Desktop.

Previously used on 
https://github.com/keymanapp/website-local-proxy/blob/cc780c20dbc647af02bf184a136eed7b46f44d74/build.sh#L50-L61
