### PR TITLE
fix: Update Development tier to assume website-local-proxy running

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -140,13 +140,13 @@
         $this->keymanweb_com = "https://keymanweb.com";
         $this->r_keymanweb_com = "https://r.keymanweb.com";
       } else if($this->tier == KeymanHosts::TIER_DEVELOPMENT) {
-        // Locally running sites via Docker need to access "host.docker.internal:[port]"
+        // Assume website-local-proxy running for local sites
         $this->s_keyman_com = "http://s.keyman.com.localhost"; // goes to website-local-proxy
-        $this->api_keyman_com = "http://host.docker.internal:8058";
-        $this->help_keyman_com = "http://host.docker.internal:8055";
+        $this->api_keyman_com = "http://api.keyman.com.localhost";
+        $this->help_keyman_com = "http://help.keyman.com.localhost";
         $this->downloads_keyman_com = "https://downloads.keyman.com"; // local dev domain is usually not available
-        $this->keyman_com = "http://host.docker.internal:8053";
-        $this->keymanweb_com = "http://host.docker.internal:8057";
+        $this->keyman_com = "http://keyman.com.localhost";
+        $this->keymanweb_com = "http://keymanweb.com.localhost";
         $this->r_keymanweb_com = "https://r.keymanweb.com"; /// local dev domain is usually not available
       } else {
         $this->s_keyman_com = "{$site_protocol}s.keyman.com{$this->site_suffix}";


### PR DESCRIPTION
Fixes #15 

This updates the Development tier to assume website-local-proxy is running

Will then need to:
* tag v0.6
* Update sites to use v0.6
    * website-local-proxy keymanapp/website-local-proxy#8
    * help.keyman.com keymanapp/help.keyman.com#1146

Rest of the sites can update later