### PR TITLE
fix: bootstrap path-handling

### DIFF
--- a/bootstrap.inc.sh
+++ b/bootstrap.inc.sh
@@ -41,7 +41,7 @@ if [[ -z ${BOOTSTRAP_ROOT+x} ]]; then
 fi
 
 if [[ -z ${BOOTSTRAP_CURRENT_VERSION_FILE+x} ]]; then
-  readonly BOOTSTRAP_CURRENT_VERSION_FILE="$(dirname $BOOTSTRAP)/.bootstrap-version"
+  readonly BOOTSTRAP_CURRENT_VERSION_FILE="$(dirname "$BOOTSTRAP")/.bootstrap-version"
 fi
 
 #


### PR DESCRIPTION
Fixes: #18.

The bootstrap.inc.sh shell script lacked proper quotes around a variable expansion, causing it to fail when using paths that included spaces.