### PR TITLE
fix: add path-escaping to start_docker_container

### DIFF
--- a/_common/docker.inc.sh
+++ b/_common/docker.inc.sh
@@ -92,7 +92,7 @@ function start_docker_container() {
     ADD_HOST="--add-host host.docker.internal:host-gateway"
   fi
 
-  docker run --rm -d -p $PORT:80 -v ${SITE_HTML} \
+  docker run --rm -d -p $PORT:80 -v "${SITE_HTML}" \
     -e S_KEYMAN_COM=localhost:$PORT_S_KEYMAN_COM \
     -e API_KEYMAN_COM=localhost:$PORT_API_KEYMAN_COM \
     --name $CONTAINER_DESC \


### PR DESCRIPTION
Apologies that we didn't catch this one at the same time as #19.  Same underlying cause, too, but we hadn't made it as far at the time due to the looping bootstrap issue.