### PR TITLE
fix: Account for TIER_TEST on CI runs

### DIFF
--- a/_common/KeymanSentry.php
+++ b/_common/KeymanSentry.php
@@ -5,10 +5,14 @@
 
   class KeymanSentry {
     static function init($dsn) {
-      if(isset($_SERVER['SERVER_NAME'])) {
+      if(file_exists(__DIR__ . '/../tier.txt')) {
+        // KeymanHosts::Instance()->Tier() doesn't exist at this point
+        $tier = trim(file_get_contents(__DIR__ . '/../tier.txt'));
+        $environment = strtolower(explode("_", $tier)[1]);
+      } else if(isset($_SERVER['SERVER_NAME'])) {
         // running from web server
         $host = $_SERVER['SERVER_NAME'];
-        if(preg_match('/\.local$/', $host))
+        if(preg_match('/\.localhost$/', $host))
           // If the host name is, e.g. api.keyman.com.local, then we'll assume this is a development environment
           $environment = 'development';
         else if(preg_match('/(^|\.)keyman-staging\.com$/', $host))


### PR DESCRIPTION
Addresses keymanapp/keyman.com#476 in parsing tier.txt to determine Tier Test in CI runs.

Alternatively, I could check the environ var `KEYMANHOSTS_TIER`
https://github.com/keymanapp/keyman.com/blob/03025d8d5f9843e1ddaca205de059aaa794cf115/.github/workflows/ci.yml#L10