### PR TITLE
chore: support flag file _control/debug

### DIFF
--- a/_common/docker.inc.sh
+++ b/_common/docker.inc.sh
@@ -73,6 +73,12 @@ function start_docker_container() {
 
   _verify_vendor_is_not_folder
 
+  if [ $BUILDER_CONFIGURATION =~ debug ]; then
+    touch _control/debug
+  else
+    rm -f _control/debug
+  fi
+
   local CONTAINER_ID=$(get_docker_container_id $CONTAINER_NAME)
   if [ ! -z "$CONTAINER_ID" ]; then
     builder_die "$HOST container $CONTAINER_ID has already been started"


### PR DESCRIPTION
This will allow, for example, .htaccess directives based on the existence of the _control/debug file, so we know if we have built in debug mode or not, for example:

```
<IfFile /var/www/html/_control/debug>
 ... add extra logging
</IfFile>
```

_control/debug should be added to .gitignore on all sites.