### PR TITLE
fix BASH warning of binary operator

### DIFF
--- a/_common/docker.inc.sh
+++ b/_common/docker.inc.sh
@@ -73,7 +73,7 @@ function start_docker_container() {
 
   _verify_vendor_is_not_folder
 
-  if [ $BUILDER_CONFIGURATION =~ debug ]; then
+  if [[ $BUILDER_CONFIGURATION =~ debug ]]; then
     touch _control/debug
   else
     rm -f _control/debug


### PR DESCRIPTION
Follows #38 

This fixes the BASH warning 
> _common/docker.inc.sh: line 76: [: =~: binary operator expected