### PR TITLE
fix: use ParsedownExtra as base class for GFMAlerts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Keyman
+Copyright (c) 2023 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/_common/GFMAlerts.php
+++ b/_common/GFMAlerts.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 
 namespace Keyman\Site\Common;
 
-use Parsedown;
+use ParsedownExtra;
 
-class GFMAlerts extends Parsedown
+class GFMAlerts extends ParsedownExtra
 {
     private $icon = array(
         // svg and path


### PR DESCRIPTION
Fixes: keymanapp/help.keyman.com#1791

Once this is merged and applied to help.keyman.com (in keymanapp/help.keyman.com#1799), we need to bring back the deleted anchor text that is in keymanapp/help.keyman.com#1755.