### PR TITLE
fix: Migrate KeymanVersion.php, update to 18.0 beta and Unicode 16.0

### DIFF
--- a/_common/KeymanVersion.php
+++ b/_common/KeymanVersion.php
@@ -1,0 +1,18 @@
+<?php
+  declare(strict_types=1);
+
+  namespace Keyman\Site\com\keyman;
+
+  class KeymanVersion {
+    /* These constant values must be updated manually when we do a beta or stable release. */
+    public const stable_version_int = 17;
+    public const beta_version_int = 17;
+    public const stable_version = '17.0';
+    public const beta_version = '17.0';
+
+    public const unicode_version = '15.0';
+
+    static function IsBetaTier(): bool {
+      return self::beta_version_int > self::stable_version_int;
+    }
+  }

--- a/_common/KeymanVersion.php
+++ b/_common/KeymanVersion.php
@@ -1,7 +1,7 @@
 <?php
   declare(strict_types=1);
 
-  namespace Keyman\Site\com\keyman;
+  namespace Keyman\Site\Common;
 
   class KeymanVersion {
     /* These constant values must be updated manually when we do a beta or stable release. */

--- a/_common/KeymanVersion.php
+++ b/_common/KeymanVersion.php
@@ -6,11 +6,11 @@
   class KeymanVersion {
     /* These constant values must be updated manually when we do a beta or stable release. */
     public const stable_version_int = 17;
-    public const beta_version_int = 17;
+    public const beta_version_int = 18;
     public const stable_version = '17.0';
-    public const beta_version = '17.0';
+    public const beta_version = '18.0';
 
-    public const unicode_version = '15.0';
+    public const unicode_version = '16.0';
 
     static function IsBetaTier(): bool {
       return self::beta_version_int > self::stable_version_int;

--- a/bootstrap.inc.sh
+++ b/bootstrap.inc.sh
@@ -104,6 +104,7 @@ function _bootstrap_configure_common() {
     JsonApiFailure.php
     KeymanHosts.php
     KeymanSentry.php
+    KeymanVersion.php
     MarkdownHost.php
     ImageRandomizer.php
   )


### PR DESCRIPTION
From [keymanapp/keyman.com#428
](https://github.com/keymanapp/keyman.com/pull/428#issue-2135543607)
> Note: this file KeymanVersion.php is a prime candidate to be moved to shared-sites as a future task.

This adds KeymanVersion.php to shared-sites.

Also, updates KeymanVersion to 18.0 beta and Unicode 16.0.

To merge when 18.0 beta is released.