### PR TITLE
fix: make server-side hostnames available through `KeymanHosts`

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -15,14 +15,24 @@
     const TIER_TEST = "TIER_TEST";
 
     public
-      $s_keyman_com, $api_keyman_com, $help_keyman_com, $downloads_keyman_com,
-      $keyman_com, $keymanweb_com, $r_keymanweb_com, $blog_keyman_com,
-      $donate_keyman_com, $translate_keyman_com, $sentry_keyman_com;
+      // major k8s hosted sites
+      $s_keyman_com, $api_keyman_com, $help_keyman_com,
+      $keyman_com, $keymanweb_com,
+
+      // other sites
+      $downloads_keyman_com, $blog_keyman_com, $translate_keyman_com,
+
+      // old endpoints
+      $r_keymanweb_com,
+
+      // PHP serverside references only
+      $SERVER_s_keyman_com, $SERVER_api_keyman_com, $SERVER_help_keyman_com,
+      $SERVER_keyman_com, $SERVER_keymanweb_com,
+      $SERVER_downloads_keyman_com;
 
     public
-      $s_keyman_com_host, $api_keyman_com_host, $help_keyman_com_host, $downloads_keyman_com_host,
-      $keyman_com_host,  $keymanweb_com_host, $r_keymanweb_com_host, $blog_keyman_com_host,
-      $donate_keyman_com_host, $translate_keyman_com_host, $sentry_keyman_com_host;
+      // Hostnames for sites -- mostly used for display purposes
+      $api_keyman_com_host, $help_keyman_com_host, $keyman_com_host;
 
     private $tier;
 
@@ -57,9 +67,7 @@
       $contents = str_replace("https://keymanweb.com", $this->keymanweb_com, $contents);
       $contents = str_replace("https://r.keymanweb.com", $this->r_keymanweb_com, $contents);
       $contents = str_replace("https://blog.keyman.com", $this->blog_keyman_com, $contents);
-      $contents = str_replace("https://donate.keyman.com", $this->donate_keyman_com, $contents);
       $contents = str_replace("https://translate.keyman.com", $this->translate_keyman_com, $contents);
-      $contents = str_replace("https://sentry.keyman.com", $this->sentry_keyman_com, $contents);
 
       return $contents;
     }
@@ -88,9 +96,7 @@
 
       // Following domains always point to production sites:
       $this->blog_keyman_com = "https://blog.keyman.com";
-      $this->donate_keyman_com = "https://donate.keyman.com";
       $this->translate_keyman_com = "https://translate.keyman.com";
-      $this->sentry_keyman_com = "https://sentry.keyman.com";
       $this->downloads_keyman_com = "https://downloads.keyman.com";
       $this->r_keymanweb_com = "https://r.keymanweb.com";
 
@@ -111,11 +117,18 @@
         // Note: locally running sites via Docker require website-local-proxy to be running
         // Append reverse-proxy port
         $local_port = isset($env['KEYMAN_COM_PROXY_PORT']) ? ':'.$env['KEYMAN_COM_PROXY_PORT'] : '';
-        $this->s_keyman_com = "http://s.keyman.com.localhost{$local_port}";
-        $this->api_keyman_com = "http://api.keyman.com.localhost{$local_port}";
-        $this->help_keyman_com = "http://help.keyman.com.localhost{$local_port}";
-        $this->keyman_com = "http://keyman.com.localhost{$local_port}";
-        $this->keymanweb_com = "http://keymanweb.com.localhost{$local_port}";
+        $this->s_keyman_com = "http://s.keyman.com.localhost$local_port";
+        $this->api_keyman_com = "http://api.keyman.com.localhost$local_port";
+        $this->help_keyman_com = "http://help.keyman.com.localhost$local_port";
+        $this->keyman_com = "http://keyman.com.localhost$local_port";
+        $this->keymanweb_com = "http://keymanweb.com.localhost$local_port";
+
+        // These are needed for PHP-side access
+        $this->SERVER_s_keyman_com = "http://host.docker.internal:8054";
+        $this->SERVER_api_keyman_com = "http://host.docker.internal:8058";
+        $this->SERVER_help_keyman_com = "http://host.docker.internal:8055";
+        $this->SERVER_keyman_com = "http://host.docker.internal:8053";
+        $this->SERVER_keymanweb_com = "http://host.docker.internal:8057";
       } else if($this->tier == KeymanHosts::TIER_PRODUCTION) {
         $this->s_keyman_com = "https://s.keyman.com";
         $this->api_keyman_com = "https://api.keyman.com";
@@ -126,20 +139,23 @@
         die("tier is '$this->tier' which is invalid\n");
       }
 
+      // Currently, we don't locally host downloads.keyman.com, so
+      // we always have the same address
+      $this->SERVER_downloads_keyman_com = $this->downloads_keyman_com;
+
+      if(empty($this->SERVER_s_keyman_com)) {
+        $this->SERVER_s_keyman_com = $this->s_keyman_com;
+        $this->SERVER_api_keyman_com = $this->api_keyman_com;
+        $this->SERVER_help_keyman_com = $this->help_keyman_com;
+        $this->SERVER_keyman_com = $this->keyman_com;
+        $this->SERVER_keymanweb_com = $this->keymanweb_com;
+      }
       $this->fixupHosts();
     }
 
     private function fixupHosts() {
-      $this->blog_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->blog_keyman_com);
-      $this->s_keyman_com_host  = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->s_keyman_com);
       $this->api_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->api_keyman_com);
       $this->help_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->help_keyman_com);
-      $this->downloads_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->downloads_keyman_com);
       $this->keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->keyman_com);
-      $this->keymanweb_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->keymanweb_com);
-      $this->r_keymanweb_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->r_keymanweb_com);
-      $this->donate_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->donate_keyman_com);
-      $this->translate_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->translate_keyman_com);
-      $this->sentry_keyman_com_host = preg_replace('/^http(s)?:\/\/(.+)$/', '$2', $this->sentry_keyman_com);
     }
   }


### PR DESCRIPTION
For local environment, we need to use host.docker.internal as the hostname, with corresponding ports, in order for the sites in their containers be able to communicate with each other. This adds `$SERVER_keyman_com` variables etc to the `KeymanHosts` class, in preparation for fixing this across each of the sites.

This is also groundwork for allowing the various containers in the production and staging environments to communicate with each other directly, rather than going via cloudflare, which should improve performance and reduce traffic on the cluster. This change will be implemented in a follow-up PR.