### PR TITLE
fix: fail on bootstrap download error

### DIFF
--- a/bootstrap.inc.sh
+++ b/bootstrap.inc.sh
@@ -58,7 +58,7 @@ function _bootstrap_download() {
   curl -H "Cache-Control: no-cache" -fs "https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/$remote_file" -o "$local_file" || (
     _bootstrap_echo "FATAL: Failed to download $remote_file"
     exit 3
-  )
+  ) || exit $?
 
 }
 


### PR DESCRIPTION
This addresses a situation where a network glitch can cause a single file in the bootstrap to fail to download, but the bootstrap itself would continue. This tended to lead to strange site issues with missing files, which can be hard to trace.

Fixes: #58