### PR TITLE
maint: add bootstrap resilience

### DIFF
--- a/bootstrap.inc.sh
+++ b/bootstrap.inc.sh
@@ -80,7 +80,7 @@ function _bootstrap_echo() {
 #
 function bootstrap_configure() {
   _bootstrap_echo "Bootstrap starting"
-   _bootstrap_download bootstrap.inc.sh "$BOOTSTRAP"
+  _bootstrap_download bootstrap.inc.sh "$BOOTSTRAP"
 
   # Record the version we downloaded -- before we re-source the script!
   echo $BOOTSTRAP_VERSION > "$BOOTSTRAP_CURRENT_VERSION_FILE"

--- a/bootstrap.inc.sh
+++ b/bootstrap.inc.sh
@@ -101,7 +101,7 @@ function bootstrap_configure() {
 #
 function _bootstrap_configure_common() {
   _bootstrap_echo "Downloading bootstrap registry to $BOOTSTRAP_REGISTRY"
-   _bootstrap_download .bootstrap-registry "$BOOTSTRAP_REGISTRY"
+  _bootstrap_download .bootstrap-registry "$BOOTSTRAP_REGISTRY"
 
   local BOOTSTRAP_LOCAL_COMMON="$BOOTSTRAP_ROOT/_common"
 

--- a/bootstrap.inc.sh
+++ b/bootstrap.inc.sh
@@ -55,8 +55,11 @@ function _bootstrap_download() {
   local remote_file="$1"
   local local_file="$2"
   _bootstrap_echo "  Downloading $remote_file"
-  curl -H "Cache-Control: no-cache" -fs "https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/$remote_file" -o "$local_file" || (
+
+  _bootstrap_try_multiple_times curl -H "Cache-Control: no-cache" -f --no-progress-meter "https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/$remote_file" -o "$local_file" || (
     _bootstrap_echo "FATAL: Failed to download $remote_file"
+    _bootstrap_echo "Note: removing $BOOTSTRAP_CURRENT_VERSION_FILE to force bootstrap on next run"
+    rm -f "$BOOTSTRAP_CURRENT_VERSION_FILE"
     exit 3
   ) || exit $?
 
@@ -77,7 +80,7 @@ function _bootstrap_echo() {
 #
 function bootstrap_configure() {
   _bootstrap_echo "Bootstrap starting"
-  _bootstrap_download bootstrap.inc.sh "$BOOTSTRAP"
+   _bootstrap_download bootstrap.inc.sh "$BOOTSTRAP"
 
   # Record the version we downloaded -- before we re-source the script!
   echo $BOOTSTRAP_VERSION > "$BOOTSTRAP_CURRENT_VERSION_FILE"
@@ -98,7 +101,7 @@ function bootstrap_configure() {
 #
 function _bootstrap_configure_common() {
   _bootstrap_echo "Downloading bootstrap registry to $BOOTSTRAP_REGISTRY"
-  _bootstrap_download .bootstrap-registry "$BOOTSTRAP_REGISTRY"
+   _bootstrap_download .bootstrap-registry "$BOOTSTRAP_REGISTRY"
 
   local BOOTSTRAP_LOCAL_COMMON="$BOOTSTRAP_ROOT/_common"
 
@@ -157,3 +160,50 @@ if [[ -z ${THIS_SCRIPT_PATH+x} ]] && [[ -f "$(dirname "$THIS_SCRIPT")/_common/bu
   # but only do this on first-run, not if re-sourced with bootstrap_configure
   cd "$THIS_SCRIPT_PATH"
 fi
+
+
+#
+# Re-runs the specified command-line instruction up to 5 times should it fail, waiting
+# 10 seconds between each attempt.  No re-runs are attempted after successful commands.
+#
+# Note: from shellHelperFunctions.sh in keymanapp/keyman
+#
+# ### Usage
+#   _bootstrap_try_multiple_times command [param1 param2...]
+#
+# ### Parameters
+#   1: $@         command-line arguments
+_bootstrap_try_multiple_times ( ) {
+  __bootstrap_try_multiple_times 0 "$@"
+}
+
+# $1  The current retry count
+# $2+ (everything else) the command to retry should it fail
+__bootstrap_try_multiple_times ( ) {
+  local RETRY_MAX=5
+  # in seconds
+  local RETRY_MIN_WAIT=10
+
+  local retryCount=$1
+  shift
+
+  if (( "$retryCount" == "$RETRY_MAX" )); then
+    echo 2>&1 "Retry limit of $RETRY_MAX attempts reached."
+    return 1
+  fi
+
+  retryCount=$(( $retryCount + 1 ))
+
+  if (( $retryCount != 1 )); then
+    echo 2>&1 "Delaying $RETRY_MIN_WAIT seconds before attempt $retryCount:"
+    echo 2>&1 "    $@"
+    sleep $RETRY_MIN_WAIT
+  fi
+
+  local code=0
+  "$@" || code=$?
+  if (( $code != 0 )); then
+    echo 2>&1 "Command failed with error $code"
+    __bootstrap_try_multiple_times $retryCount "$@"
+  fi
+}


### PR DESCRIPTION
Handle GitHub or network instability with 5 retries on bootstrap downloads (except for the single bootstrap.inc.sh initially sourced on first use), and deal with failure by removing .bootstrap-version, so that bootstrap is forced again on next run.

This should hopefully make most deployments and CI runs self-healing as the network instability resolves, and in many cases hopefully the 5 retries will be sufficient to complete deployment/CI in one go.

Sample run with faked missing file "xassets" instead of "assets":

```
$ ./build.sh stop
[bootstrap] Bootstrap required
[bootstrap] Bootstrap starting
[bootstrap] Downloading bootstrap registry to /d/Projects/keyman/sites/help.keyman.com/resources/.bootstrap-registry
[bootstrap] Downloading _common files
[bootstrap]   Downloading _common/assets/img/gfm-limits-1.png
[bootstrap]   Downloading _common/assets/img/gfm-limits-1.324a4970ffdfdfb8e66e63df5d9d79d1725793c3.png
[bootstrap]   Downloading _common/assets/img/gfm-limits-2.png
[bootstrap]   Downloading _common/assets/img/gfm-limits-2.3974f1a1df6cecf9a2b792fafa21f190214639f2.png
[bootstrap]   Downloading _common/assets/img/gfm-limits-3.png
[bootstrap]   Downloading _common/assets/img/gfm-limits-3.4b6a74bee45225808fafb33733b171b917bef90b.png
[bootstrap]   Downloading _common/assets/img/gfm-limits-4.png
[bootstrap]   Downloading _common/assets/img/gfm-limits-4.f871c142a8f9e023bb34cc656c0f67ef4e15e555.png
[bootstrap]   Downloading _common/xassets/img/gfmalerts.png
curl: (22) The requested URL returned error: 404
Command failed with error 22
Delaying 10 seconds before attempt 2:
    curl -H Cache-Control: no-cache -f --no-progress-meter https://raw.githubusercontent.com/keymanapp/shared-sites/v0.22/_common/xassets/img/gfmalerts.png -o /d/Projects/keyman/sites/help.keyman.com/resources/../_common/xassets/img/gfmalerts.png
curl: (22) The requested URL returned error: 404
Command failed with error 22
Delaying 10 seconds before attempt 3:
    curl -H Cache-Control: no-cache -f --no-progress-meter https://raw.githubusercontent.com/keymanapp/shared-sites/v0.22/_common/xassets/img/gfmalerts.png -o /d/Projects/keyman/sites/help.keyman.com/resources/../_common/xassets/img/gfmalerts.png
curl: (22) The requested URL returned error: 404
Command failed with error 22
Delaying 10 seconds before attempt 4:
    curl -H Cache-Control: no-cache -f --no-progress-meter https://raw.githubusercontent.com/keymanapp/shared-sites/v0.22/_common/xassets/img/gfmalerts.png -o /d/Projects/keyman/sites/help.keyman.com/resources/../_common/xassets/img/gfmalerts.png
curl: (22) The requested URL returned error: 404
Command failed with error 22
Delaying 10 seconds before attempt 5:
    curl -H Cache-Control: no-cache -f --no-progress-meter https://raw.githubusercontent.com/keymanapp/shared-sites/v0.22/_common/xassets/img/gfmalerts.png -o /d/Projects/keyman/sites/help.keyman.com/resources/../_common/xassets/img/gfmalerts.png
curl: (22) The requested URL returned error: 404
Command failed with error 22
Retry limit of 5 attempts reached.
[bootstrap] FATAL: Failed to download _common/xassets/img/gfmalerts.png
[bootstrap] Note: Removing /d/Projects/keyman/sites/help.keyman.com/resources/.bootstrap-version so bootstrap will be forced to re-run
```