### PR TITLE
feat: one script to control all repos

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -30,14 +30,7 @@ jobs:
 
       - name: Clone target repositories
         run: |
-          repositories=(
-            "keymanapp/api.keyman.com"
-            "keymanapp/help.keyman.com"
-            "keymanapp/keyman.com"
-            "keymanapp/keymanweb.com"
-            "keymanapp/s.keyman.com"
-            "keymanapp/website-local-proxy"
-          )
+          . sites.inc.sh
           mkdir -p keymanapp
           cd keymanapp
           for repo in "${repositories[@]}"; do

--- a/_common/docker.inc.sh
+++ b/_common/docker.inc.sh
@@ -18,7 +18,7 @@ function stop_docker_container() {
   if [ ! -z "$CONTAINER_ID" ]; then
     docker container stop $CONTAINER_ID
   else
-    echo "No Docker container to stop"
+    builder_echo "No Docker container to stop"
   fi
 }
 
@@ -81,12 +81,14 @@ function start_docker_container() {
 
   local CONTAINER_ID=$(get_docker_container_id $CONTAINER_NAME)
   if [ ! -z "$CONTAINER_ID" ]; then
-    builder_die "$HOST container $CONTAINER_ID has already been started"
+    builder_echo green "Container $CONTAINER_ID has already been started, listening on http://$HOST:$PORT"
   fi
 
   # Start the Docker container
   if [ -z $(get_docker_image_id $IMAGE_NAME) ]; then
-    builder_die "ERROR: Docker container doesn't exist. Run \"./build.sh build\" first"
+    builder_echo yellow "Docker container doesn't exist. Running \"./build.sh build\" first"
+    "$THIS_SCRIPT" build
+    builder_echo green "Docker container created successfully"
   fi
 
   if [[ $OSTYPE =~ msys|cygwin ]]; then

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,30 @@
 #!/usr/bin/env bash
-set -eu
+# Keyman is copyright (C) SIL Global. MIT License.
 
-readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
-readonly THIS_SCRIPT_PATH="$(dirname "$THIS_SCRIPT")"
+## START STANDARD BUILD SCRIPT INCLUDE
+# adjust relative paths as necessary
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+. "${THIS_SCRIPT%/*}/_common/builder.inc.sh"
+## END STANDARD BUILD SCRIPT INCLUDE
+
+. "$THIS_SCRIPT_PATH/sites.inc.sh"
+
+builder_describe "Build common site resources and coordinate sites" \
+  "build-files        Build list of assets for sharing" \
+  \
+  "clone              Clone keyman website repositories" \
+  "pull               Switch to master and pull latest changes to keyman website repositories, DELETES MERGED BRANCHES" \
+  "configure          Configure keyman website repositories" \
+  "clean              Clean keyman website repositories" \
+  "build              Build docker images for keyman website repositories" \
+  "start              Start Docker containers for keyman website repositories" \
+  "stop               Stop Docker containers for keyman website repositories" \
+  "test               Test keyman website repositories in Docker" \
+  \
+  ":shared-sites      This repo, for build-files" \
+  "${site_targets[@]}"
+
+builder_parse "$@"
 
 cd "$THIS_SCRIPT_PATH"
 
@@ -16,7 +38,6 @@ cd "$THIS_SCRIPT_PATH"
 #
 # TODO: we could tweak the asset management in the future to use symbolic links.
 #
-
 build_file_list() {
   local regtemp="$(mktemp)"
   local filename
@@ -50,4 +71,41 @@ build_file_list() {
   find _common -type f ! -name README.md ! -path '_common/assets/*'  -printf '%P\n' >> .bootstrap-registry
 }
 
-build_file_list
+builder_run_action        build-files:shared-sites     build_file_list
+
+# Site actions
+
+site_clone() {
+  local site=$1
+  cd "$THIS_SCRIPT_PATH/.."
+  if [[ ! -d $site ]]; then
+    git clone https://github.com/keymanapp/$site
+  fi
+}
+
+site_pull() {
+  local site=$1
+  cd "$THIS_SCRIPT_PATH/../$site"
+  # note: this will die if there are changes that prevent branch switch
+  git switch master
+  git pull -p
+  # delete any upstream-tracked merged/deleted branches, ignore errors where
+  # local changes prevent deletion. This keeps the repo reasonably up-to-date,
+  # without any risk of damage
+  (git for-each-ref --format '%(refname:short) %(upstream:track)' | grep '\[gone\]' | cut -d' ' -f 1 - | xargs -r git branch -d) || true
+}
+
+site_action() {
+  local action=$1
+  local site=$2
+  cd "$THIS_SCRIPT_PATH/../$site"
+  ./build.sh $action
+}
+
+for action in clone pull; do
+  for site in ${sites[@]}; do builder_run_action $action:$site site_$action $site; done
+done
+
+for action in configure clean build start stop test; do
+  for site in ${sites[@]}; do builder_run_action $action:$site site_action $action $site; done
+done

--- a/sites.inc.sh
+++ b/sites.inc.sh
@@ -1,0 +1,8 @@
+# shellcheck shell=bash
+# Keyman is copyright (C) SIL Global. MIT License.
+
+# Site repositories that run on Docker
+sites=(api.keyman.com help.keyman.com keyman.com keymanweb.com s.keyman.com website-local-proxy)
+
+repositories=( ${sites[@]/#/keymanapp/})
+site_targets=( ${sites[@]/#/:})


### PR DESCRIPTION
./build.sh now available to run common commands across all site repos:

* `clone`:     Clone keyman website repositories
* `pull`:      Switch to master and pull latest changes to keyman website repositories, DELETES MERGED BRANCHES
* `configure`: Configure keyman website repositories
* `clean`:     Clean keyman website repositories
* `build`:     Build docker images for keyman website repositories
* `start`:     Start Docker containers for keyman website repositories
* `stop`:      Stop Docker containers for keyman website repositories
* `test`:      Test keyman website repositories in Docker

Note that `start` action in docker.inc.sh has been tweaked to be more resilient/idempotent -- you can run it without running build first, and now it won't error if the site is already started.

Fixes: #78
Test-bot: skip