### PR TITLE
feat: Pass builder configuration to Docker build step

### DIFF
--- a/_common/docker.inc.sh
+++ b/_common/docker.inc.sh
@@ -53,11 +53,15 @@ function _verify_vendor_is_not_folder() {
 function build_docker_container() {
   local IMAGE_NAME=$1
   local CONTAINER_NAME=$2
+  local BUILDER_CONFIGURATION="release"
+  if [[ $# -eq 3 ]]; then
+    BUILDER_CONFIGURATION=$3
+  fi
 
   _verify_vendor_is_not_folder
 
   # Download docker image. --mount option requires BuildKit
-  DOCKER_BUILDKIT=1 docker build -t $IMAGE_NAME .
+  DOCKER_BUILDKIT=1 docker build -t $IMAGE_NAME --build-arg BUILDER_CONFIGURATION="${BUILDER_CONFIGURATION}" .
 }
 
 function start_docker_container() {


### PR DESCRIPTION
For addressing keymanapp/keyman.com#493

Pass the builder configuration to the Docker build step

This allows the Docker image to build dev dependencies for testing (e.g. BUILDER_CONFIGURATION = debug will install phpunit for running PHP unit tests)

Test-bot: skip