### PR TITLE
fix: allow markdown files with only a redirect header

### DIFF
--- a/_common/MarkdownHost.php
+++ b/_common/MarkdownHost.php
@@ -59,7 +59,7 @@
       $lines = explode("\n", $contents);
       $headers = [];
 
-      $found = count($lines) > 3 && rtrim($lines[0]) == '---';
+      $found = count($lines) > 2 && rtrim($lines[0]) == '---';
       if($found) {
         for($i = 1; $i < count($lines); $i++) {
           if($lines[$i] == '---') break;


### PR DESCRIPTION
A .md file with only a redirect header is only 3 lines long.

Test-bot: skip