### PR TITLE
chore: update multi-labeler to 5.0.0

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - name: Update labels based on PR title
       id: labeler
-      uses: fuxingloh/multi-labeler@f5bd7323b53b0833c1e4ed8d7b797ae995ef75b4 # v2.0.1
+      uses: fuxingloh/multi-labeler@bcd50af464202999e57f556b4aefcf05a34abf85 # v5.0.0
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         config-path: .github/multi-labeler.yml


### PR DESCRIPTION
This moves to node v24.

Relates-to: keymanapp/s.keyman.com#1607
Test-bot: skip